### PR TITLE
Fix: "Incorrect use of parent data widget"

### DIFF
--- a/birthdaytracker/lib/widgets/birthday_bar_datebox.dart
+++ b/birthdaytracker/lib/widgets/birthday_bar_datebox.dart
@@ -14,7 +14,10 @@ class BdayBarDateBox extends StatelessWidget {
       height: 80,
       width: 80,
       color: Colors.black45,
-      child: Column(children: [DateBoxMonth(month), DateBoxDay(day)]),
+      child: Column(children: [
+        Expanded(flex: 2, child: DateBoxMonth(month)),
+        Expanded(flex: 3, child: DateBoxDay(day)),
+      ]),
     );
   }
 }

--- a/birthdaytracker/lib/widgets/birthday_bar_name.dart
+++ b/birthdaytracker/lib/widgets/birthday_bar_name.dart
@@ -7,13 +7,12 @@ class BdayBarName extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-        child: Padding(
+    return Padding(
       padding: const EdgeInsets.all(16),
       child: Text(
         name,
         style: const TextStyle(fontSize: 22, color: Colors.black87),
       ),
-    ));
+    );
   }
 }

--- a/birthdaytracker/lib/widgets/birthday_profile_bar.dart
+++ b/birthdaytracker/lib/widgets/birthday_profile_bar.dart
@@ -31,7 +31,7 @@ class BirthdayProfileBar extends StatelessWidget {
             child:
                 Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
               ProfilePicture(profile, 68),
-              BdayBarName(profile.name),
+              Expanded(child: BdayBarName(profile.name)),
               BdayBarDateBox(profile.month, profile.day),
             ]),
           ),

--- a/birthdaytracker/lib/widgets/date_box_day.dart
+++ b/birthdaytracker/lib/widgets/date_box_day.dart
@@ -7,13 +7,10 @@ class DateBoxDay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      flex: 3,
-      child: Center(
-          child: Text(
-        day.toString(),
-        style: const TextStyle(color: Colors.white, fontSize: 28),
-      )),
-    );
+    return Center(
+        child: Text(
+      day.toString(),
+      style: const TextStyle(color: Colors.white, fontSize: 28),
+    ));
   }
 }

--- a/birthdaytracker/lib/widgets/date_box_month.dart
+++ b/birthdaytracker/lib/widgets/date_box_month.dart
@@ -21,11 +21,8 @@ class DateBoxMonth extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      flex: 2,
-      child: Center(
-          child: Text(months[month - 1],
-              style: const TextStyle(color: Colors.white, fontSize: 16))),
-    );
+    return Center(
+        child: Text(months[month - 1],
+            style: const TextStyle(color: Colors.white, fontSize: 16)));
   }
 }

--- a/birthdaytracker/lib/widgets/profile_picture_element.dart
+++ b/birthdaytracker/lib/widgets/profile_picture_element.dart
@@ -25,12 +25,10 @@ class ProfilePictureElement extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: ClipOval(
-        child: FittedBox(
-          fit: BoxFit.cover,
-          child: getChild(),
-        ),
+    return ClipOval(
+      child: FittedBox(
+        fit: BoxFit.cover,
+        child: getChild(),
       ),
     );
   }


### PR DESCRIPTION
- moved instances of Expanded into higher contexts directly under Rows & Columns
- removed unnecessary instances of Expanded